### PR TITLE
Remove unused and incorrect prototype for flushICache()

### DIFF
--- a/runtime/oti/jitprotos.h
+++ b/runtime/oti/jitprotos.h
@@ -124,7 +124,6 @@ void * j9ThunkInvokeExactHelperFromSignature(void * jitConfig, UDATA signatureLe
 
 /* prototypes from CodertVMHelpers.cpp */
 void initializeDirectJNI (J9JavaVM *vm);
-void flushICache(J9VMThread *currentThread, void *memoryPointer, UDATA byteAmount);
 
 /* prototypes from jsr292.c */
 void i2jFSDAssert();


### PR DESCRIPTION
Signed-off-by: Boris Shingarov <shingarov@labware.com>